### PR TITLE
feat(tools): add elm-collector-config-backup.py; document userPermission

### DIFF
--- a/elm-knowledge.md
+++ b/elm-knowledge.md
@@ -363,6 +363,29 @@ elm CollectorGroupById --id <id> -f numOfHosts,numOfInstances
 
 `CollectorList`'s `hostname` (and usually `description`) is typically the `DOMAIN\HOSTNAME` form (e.g. `CORP\NEWEDGE03`) or an FQDN — not the bare host label. So matching a collector by an exact bare name fails; match by numeric `id`, or by a substring/partial match. (This is why `tools/lm-collector-reachability-run-all.ps1 -Candidate` resolves id → exact hostname/description → unambiguous substring.)
 
+### userPermission — the calling token's effective rights on each object
+
+Many LM list/get responses include a `userPermission` field: a comma-separated
+list of what the **calling API token** may do to *that specific object* — e.g.
+`read`, `write`, `write,debug`. Bare `read` = read-only; presence of `write` =
+manage. It reflects the token's role, so the same object shows different
+`userPermission` values to different tokens.
+
+It appears on ~22 object types, including `Collector`, `Device`, `DeviceGroup`,
+`Dashboard`(+Group), `Website`(+Group), `Report`(+Group), `Role`, `Admin`,
+`APIToken`, `LogQueryGroup`, and `Widget`. Request it like any other field:
+
+```shell
+elm CollectorList -s0 -f id,hostname,userPermission
+```
+
+Practical use — **gate on `userPermission` instead of probing sensitive blobs.**
+A collector's config-file fields (`wrapperConf`, `collectorConf`, `sbproxyConf`,
+`watchdogConf`, `websiteConf`) are only returned to a token whose
+`userPermission` includes `write`; a `read`-only token gets the literal string
+`"{}"` for each. So before a collector-config backup, check `userPermission` per
+collector rather than fetching the blobs and inspecting them for `{}`.
+
 ### deviceType — distinguishes real devices from cloud, services, and k8s
 
 `deviceType` on `DeviceList`/`DeviceById` records is an integer that classifies what a "device" actually is. LM models many non-device things as `device` objects; this field tells them apart.

--- a/elm-notes.yaml
+++ b/elm-notes.yaml
@@ -1335,6 +1335,7 @@ CollectorList:
     calculatedThreshold: float   # current load vs autoBalanceInstanceCountThreshold; only non-zero for auto-balance groups
     acked:              boolean  # down alert has been acknowledged
     nextUpgradeInfo:    object   # {majorVersion, minorVersion, mandatory, stable, upgradeTime, upgradeTimeEpoch}
+    userPermission:     string   # calling token's effective rights on this collector: "read" (read-only) or "write"/"write,debug" (manage). Only write/manage tokens can read the *Conf config-file fields
   gotchas:
     - "collectorDeviceId=0 means the collector has no device record in LM -- you cannot query its host metrics (CPU, memory) via DeviceDatasourceInstanceData etc."
     - "collectorDeviceId (when non-zero) is the device ID of the collector host in DeviceList -- use it to identify which devices in a group are themselves collector hosts so reachability/cross-collector checks can skip them (a collector is monitored from itself; collector name and device name need not match)"
@@ -1345,6 +1346,7 @@ CollectorList:
     - "numberOfInstances is 0 for non-auto-balance collectors -- it only tracks auto-balance load distribution"
     - "backupAgentId is a single value -- a collector can only have one backup; no chain failover"
     - "enableFailBack only takes effect if backupAgentId is set; harmless but meaningless when 0"
+    - "The config-file fields (wrapperConf/collectorConf/sbproxyConf/watchdogConf/websiteConf) are only returned to a token whose userPermission includes 'write'; a read-only token gets the literal string '{}' for every one of them. Gate a collector-config backup on userPermission (per collector, so RBAC-scoped access still works) instead of fetching the blobs and inspecting for '{}'. userPermission is an LM-wide field (~22 object types) -- see elm-knowledge.md."
   patterns:
     all_collectors_health: |
       # Full health overview sorted by worst first (DOWN + most hosts = most urgent)

--- a/tools/README.md
+++ b/tools/README.md
@@ -16,6 +16,7 @@ script also responds to `-h`/`--help`.
 ## Contents
 
 - [API speed test](#api-speed-test) — `tools/elm-speedtest.sh`
+- [Backups](#backups) — `tools/elm-backup.sh`, `tools/elm-collector-config-backup.py`
 - [Datasource usage matrix](#datasource-usage-matrix) — `tools/elm-datasource-matrix.py`
 - [Host SDTs](#host-sdts) — `tools/elm-host-sdts.sh`
 
@@ -41,6 +42,49 @@ Available list endpoints:
 `DeviceList` `EscalationChainList` `EventSourceList` `IntegrationList`
 `NetscanList` `RecipientGroupList` `ReportGroupList` `ReportList` `RoleList`
 `SDTList` `WebsiteGroupList` `WebsiteList`
+
+## Backups
+
+Two read-only snapshotters that record what a portal looks like for auditing and
+change-tracking. Neither is a **restore** mechanism — elm is read-only and LM has
+no bulk import; the value is a diffable record of what the portal looked like.
+The tools do **not** version anything themselves — each run overwrites the
+previous snapshot in place. To get history you either version it yourself (point
+a separate git repo at the backup dir and commit after each run, then `git log
+-p` shows exactly what changed) or pass `--date`, which writes each run under a
+UTC datestamp subdir (`.../YYYY-MM-DD/`) so different days don't overwrite each
+other. Both label output by LM **account name** (resolved from elm's own request
+URL, not the credentials `.ini`), default their root to `$ELM_BACKUP_DIR` or
+`~/elm-backup` (**outside** this code repo so a backup is never committed), and
+refuse to write inside a git work tree unless `--dir` is given explicitly.
+
+`tools/elm-backup.sh` dumps configuration **objects** — alerting (alert rules,
+escalation/action chains, action rules, recipient groups, integrations) and
+collectors (collector/group/version lists) — one JSONL file per endpoint
+(`<endpoint>.jsonl`). Active/historical alerts are excluded (transient telemetry,
+not config).
+
+```shell
+tools/elm-backup.sh                       # default profile -> ~/elm-backup/<account>/
+tools/elm-backup.sh -p prod --date        # prod, history kept by date
+ELM_BACKUP_DIR=/srv/lm tools/elm-backup.sh
+```
+
+`tools/elm-collector-config-backup.py` captures the thing `elm-backup.sh` leaves
+out: each collector's actual **config files** (`collectorConf`, `wrapperConf`,
+`sbproxyConf`, `watchdogConf`, `websiteConf`), decoded into a per-collector tree
+(`collectors/<id>-<hostname>/<conf>`) — one text file per non-empty conf, so diffs
+are clean. Those fields are permission-gated: LM only returns them to a token
+whose `userPermission` on the collector includes `write` (Manage); a read-only
+token gets `"{}"`. The tool reads `userPermission` up front, so it **skips**
+read-only collectors (reporting a summary) and RBAC-scoped tokens back up exactly
+what they can. If **no** collector is readable it aborts (exit 3) and writes
+nothing rather than leaving a tree of empty files.
+
+```shell
+tools/elm-collector-config-backup.py               # default profile
+tools/elm-collector-config-backup.py -p prod --date
+```
 
 ## Datasource usage matrix
 

--- a/tools/elm-backup.sh
+++ b/tools/elm-backup.sh
@@ -3,8 +3,9 @@
 # JSONL files for auditing, change-tracking, and disaster reference.
 #
 # This is a config-as-data backup, NOT a restore mechanism. elm is read-only:
-# LM has no bulk import, so the value here is a versioned, diffable record of
-# what your portal looked like. To write anything back you would use the
+# LM has no bulk import, so the value here is a diffable record of what your
+# portal looked like (each run overwrites in place; version it with a separate
+# git repo, or keep dated snapshots with --date). To write anything back you would use the
 # Logic.Monitor PowerShell module (New-/Set-/Import-/Restore- cmdlets) against
 # these snapshots; see CLAUDE.md notes on that round-trip's caveats (read-only
 # fields, ID remapping, redacted secrets).

--- a/tools/elm-collector-config-backup.py
+++ b/tools/elm-collector-config-backup.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""elm-collector-config-backup: snapshot every LogicMonitor Collector's config
+files (agent/wrapper/sbproxy/watchdog/website .conf) to a diffable, per-collector
+tree for auditing, change-tracking, and disaster reference.
+
+Companion to elm-backup.sh: that tool dumps alerting + collector *objects* as
+JSONL; this one captures the collectors' actual *config-file* contents, which
+elm-backup deliberately does not fetch (large, permission-gated blobs). Both are
+read-only snapshots, NOT a restore mechanism -- LM has no bulk import. The value
+is a diffable record of what each collector's config looked like. This tool does
+not version anything itself -- each run overwrites the previous snapshot in place.
+For history, either point a separate git repo at the backup dir and commit after
+each run (`git log -p` then shows what changed), or use --date (below) to keep
+dated snapshots.
+
+Permissions:
+  The config-file fields (wrapperConf/collectorConf/sbproxyConf/watchdogConf/
+  websiteConf) are only returned to an API token whose `userPermission` on the
+  collector includes `write` (Manage). A read-only token gets the literal string
+  "{}" for each. This tool reads `userPermission` up front:
+    * if NO collector is writable by this token, it aborts (exit 3) with an
+      actionable message and writes nothing, rather than producing a tree of
+      empty files;
+    * otherwise it backs up every writable collector, SKIPS the read-only ones,
+      and prints a readable/skipped summary. RBAC-scoped tokens (write on some
+      collectors, read on others) back up exactly what they can.
+  If the portal omits `userPermission` entirely, it falls back to gating on conf
+  content (a collector with at least one non-empty conf is treated as readable).
+
+Output:
+  One directory per collector under
+    DIR/ACCOUNT/[DATE/]collectors/<id>-<hostname>/
+  with one decoded text file per non-empty conf:
+    collectorConf  wrapperConf  sbproxyConf  watchdogConf  websiteConf
+  ACCOUNT is the LM account_name (portal), resolved from elm itself (its request
+  URL), not the credentials .ini. Hostnames are sanitised for the filesystem
+  (the usual DOMAIN\\HOST form has its backslash/slash turned into '_').
+
+  DIR defaults to $ELM_BACKUP_DIR or ~/elm-backup -- intentionally OUTSIDE this
+  code repo so backups (which contain portal data) are never accidentally
+  staged/committed. The tool refuses to write inside a git work tree unless --dir
+  is given explicitly.
+
+Examples:
+  elm-collector-config-backup.py                       # default 'config' profile
+  elm-collector-config-backup.py -p prod --date        # prod, history by date
+  ELM_BACKUP_DIR=/srv/lm elm-collector-config-backup.py
+
+Status messages go to stderr. Requires: elm on PATH.
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+# The collector config-file fields. Edit to add/remove conf types.
+CONF_FIELDS = ["wrapperConf", "collectorConf", "sbproxyConf",
+               "watchdogConf", "websiteConf"]
+
+# Exit codes: 0 ok; 1 fetch/parse error; 2 usage/precondition; 3 token cannot
+# read ANY collector config (nothing written).
+EXIT_OK, EXIT_ERR, EXIT_USAGE, EXIT_NOPERM = 0, 1, 2, 3
+
+
+def err(*args):
+    print(*args, file=sys.stderr)
+
+
+def is_empty(v):
+    """A real conf is never empty; LM returns "{}" (or "") when the field is not
+    readable by this token, or genuinely absent for that conf type."""
+    return v is None or str(v).strip() in ("", "{}")
+
+
+def perms(row):
+    return {p.strip().lower()
+            for p in str(row.get("userPermission", "")).split(",") if p.strip()}
+
+
+def safe(name):
+    """DOMAIN\\HOST / FQDN -> filesystem-safe; collapse anything unusual to '_'."""
+    return re.sub(r"[^A-Za-z0-9._-]+", "_", str(name)).strip("._") or "unknown"
+
+
+def resolve_account(profile):
+    """Label the backup by LM account_name, not the elm profile name (a profile
+    can point at different accounts over time). `elm -f api` prints the request
+    URL it builds (https://<account>.logicmonitor.com/...); one cheap probe
+    yields the account with no .ini parsing. The Authorization line it also
+    prints (HMAC signature) is discarded. Returns the account, or None."""
+    try:
+        out = subprocess.run(
+            ["elm", "-p", profile, "-f", "api", "CollectorList", "-s1"],
+            capture_output=True, text=True, check=False).stdout
+    except OSError:
+        return None
+    m = re.search(r"^https://([^./]+)\.logicmonitor\.com/", out, re.M)
+    return m.group(1) if m else None
+
+
+def fetch_collectors(profile):
+    """One bulk fetch: id + hostname + userPermission + all conf fields (-s0 =
+    all collectors, up to LM's 1000 cap). Returns (rows, error_message)."""
+    cmd = ["elm", "-p", profile, "-f", "json", "CollectorList", "-s0",
+           "-f", "id,hostname,userPermission," + ",".join(CONF_FIELDS)]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        return None, (proc.stderr.strip() or f"elm exited {proc.returncode}")
+    try:
+        doc = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        return None, f"could not parse elm JSON: {e}"
+    # elm -f json wraps rows as {"CollectorList": [...]}; tolerate a bare list.
+    rows = doc.get("CollectorList", doc) if isinstance(doc, dict) else doc
+    if not isinstance(rows, list):
+        return None, "unexpected JSON shape (no CollectorList array)"
+    return rows, None
+
+
+def backup(rows, collectors_dir):
+    """Split rows into per-collector conf files. Returns a summary dict."""
+    total = len(rows)
+    saw_perm = False        # did the API return userPermission at all?
+    backed_up = files_out = 0
+    skipped_ro = []         # read-only (no write perm)
+    empty_write = []        # writable but confs still empty (odd)
+
+    for row in rows:
+        cid = row.get("id", "?")
+        host = row.get("hostname") or row.get("description") or f"id{cid}"
+        if "userPermission" in row:
+            saw_perm = True
+        writable = "write" in perms(row)
+
+        confs = {f: row.get(f) for f in CONF_FIELDS}
+        has_content = any(not is_empty(v) for v in confs.values())
+        # Gate primarily on userPermission (authoritative, per-collector ->
+        # RBAC safe). If the portal omits it entirely, fall back to conf content.
+        if not saw_perm:
+            writable = has_content
+
+        if not writable:
+            skipped_ro.append((cid, host))
+            continue
+        if not has_content:
+            empty_write.append((cid, host))
+            continue
+
+        cdir = os.path.join(collectors_dir, f"{cid}-{safe(host)}")
+        os.makedirs(cdir, exist_ok=True)
+        for f in CONF_FIELDS:
+            v = confs[f]
+            if is_empty(v):
+                continue
+            text = v if isinstance(v, str) else json.dumps(v, indent=2)
+            if not text.endswith("\n"):
+                text += "\n"
+            with open(os.path.join(cdir, f), "w") as out:
+                out.write(text)
+            files_out += 1
+        backed_up += 1
+
+    return dict(total=total, saw_perm=saw_perm, backed_up=backed_up,
+                files_out=files_out, skipped_ro=skipped_ro,
+                empty_write=empty_write)
+
+
+def _sample(pairs, limit=8):
+    shown = ", ".join(f"{c}({h})" for c, h in pairs[:limit])
+    return shown + (" ..." if len(pairs) > limit else "")
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        prog="elm-collector-config-backup.py",
+        description="Snapshot every collector's config files to a diffable tree.")
+    p.add_argument("-p", "--profile", default="config",
+                   help="elm credential profile (default: config)")
+    p.add_argument("-d", "--dir", default=None,
+                   help="backup root dir (default: $ELM_BACKUP_DIR or ~/elm-backup)")
+    p.add_argument("--date", action="store_true",
+                   help="nest output under a UTC datestamp subdir (history)")
+    args = p.parse_args(argv)
+
+    if not shutil.which("elm"):
+        err("elm-collector-config-backup: 'elm' not found in PATH")
+        return EXIT_USAGE
+
+    # Resolve root; remember whether the user chose it explicitly (guard below).
+    root_explicit = args.dir is not None
+    root = args.dir or os.environ.get("ELM_BACKUP_DIR") \
+        or os.path.join(os.path.expanduser("~"), "elm-backup")
+
+    # Safety net: refuse to write backups inside a git work tree unless the user
+    # explicitly chose the location with --dir. Prevents accidentally committing
+    # a portal backup into this (or any) repo.
+    if not root_explicit:
+        parent = os.path.dirname(os.path.abspath(root))
+        inside = subprocess.run(
+            ["git", "-C", parent, "rev-parse", "--is-inside-work-tree"],
+            capture_output=True, text=True, check=False)
+        if inside.returncode == 0 and inside.stdout.strip() == "true":
+            repo = subprocess.run(
+                ["git", "-C", parent, "rev-parse", "--show-toplevel"],
+                capture_output=True, text=True, check=False).stdout.strip()
+            err(f"elm-collector-config-backup: default dir '{root}' is inside "
+                f"git repo '{repo}'.")
+            err("  Refusing to write backups into a code repo. Set ELM_BACKUP_DIR "
+                "or pass --dir DIR to a location outside any repo.")
+            return EXIT_USAGE
+
+    label = resolve_account(args.profile)
+    if not label:
+        err("elm-collector-config-backup: could not resolve account_name (probe "
+            f"failed); falling back to profile name '{args.profile}'.")
+        label = args.profile
+
+    outdir = os.path.join(root, label)
+    if args.date:
+        from datetime import datetime, timezone
+        outdir = os.path.join(outdir, datetime.now(timezone.utc).strftime("%Y-%m-%d"))
+    collectors_dir = os.path.join(outdir, "collectors")
+
+    err(f"elm-collector-config-backup: profile '{args.profile}' (account "
+        f"'{label}') -> {collectors_dir}")
+
+    rows, error = fetch_collectors(args.profile)
+    if error:
+        err(f"elm-collector-config-backup: CollectorList fetch failed: {error}")
+        return EXIT_ERR
+
+    s = backup(rows, collectors_dir)
+
+    # Preflight abort: token could not read ANY collector's config.
+    if s["backed_up"] == 0 and not s["empty_write"]:
+        err(f"elm-collector-config-backup: no collector configs are readable by "
+            f"profile's token ({s['total']} collector(s) seen).")
+        if s["saw_perm"]:
+            err("  userPermission on every collector is read-only (no 'write'). "
+                "Collector config files require a Manage/write-level role.")
+        else:
+            err("  All conf fields came back empty ('{}'). The token likely lacks "
+                "Manage/write permission on collectors.")
+        err("  Nothing was written.")
+        return EXIT_NOPERM
+
+    err(f"elm-collector-config-backup: backed up {s['backed_up']}/{s['total']} "
+        f"collector(s), {s['files_out']} conf file(s) -> {collectors_dir}")
+    if s["skipped_ro"]:
+        err(f"  skipped {len(s['skipped_ro'])} read-only collector(s): "
+            + _sample(s["skipped_ro"]))
+    if s["empty_write"]:
+        err(f"  {len(s['empty_write'])} writable collector(s) returned empty "
+            "configs (nothing to save): " + _sample(s["empty_write"]))
+    err("elm-collector-config-backup: done.")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a read-only snapshotter for every collector's on-box config files, plus supporting docs.

- **`tools/elm-collector-config-backup.py`** — backs up each collector's `collectorConf`/`wrapperConf`/`sbproxyConf`/`watchdogConf`/`websiteConf` into a diffable per-collector tree (`collectors/<id>-<hostname>/<conf>`), one text file per non-empty conf.
- **Permission-aware:** those fields are only returned to a token whose `userPermission` on the collector includes `write` (Manage); a read-only token gets `"{}"`. The tool reads `userPermission` up front, **skips** read-only collectors (with a summary), and **aborts (exit 3) writing nothing** if none are readable — so RBAC-scoped tokens back up exactly what they can. Falls back to conf-content gating if a portal omits `userPermission`.
- Mirrors `elm-backup.sh` conventions: account-name label, `$ELM_BACKUP_DIR`/`~/elm-backup` default, `--date`, git-worktree guard.

## Docs

- `elm-knowledge.md` + `elm-notes.yaml`: document `userPermission` as an LM-wide field (~22 object types) and that the collector config-file fields need a write/Manage token.
- `tools/README.md`: new **Backups** section covering both `elm-backup.sh` and the new tool.
- Corrected the "versioned" wording in `tools/README.md`, the new script, and `elm-backup.sh` — the tools overwrite in place and do **not** version themselves (use a separate git repo or `--date` for history).

## Testing

Exercised offline against synthetic `CollectorList` fixtures with a fake `elm` on `PATH`:

| Scenario | Result |
|---|---|
| Mixed perms/content | rc 0 — backs up writable+content, skips read-only, reports writable-but-empty |
| All read-only | rc 3 — nothing written, `userPermission`-aware abort |
| No `userPermission` field | rc 0 — conf-content fallback |
| Default dir inside a repo | rc 2 — refused |

`py_compile` clean. All changed files are non-generated (no `make render` needed).